### PR TITLE
Update gradle version in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<gradle.version>1.6</gradle.version>
+		<gradle.version>2.1</gradle.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Compilation was not successful because the maven repository does not contain gradle-base-services-groovy in version 1.6. The updated version 2.1 is the oldest possible version for all of the gradle dependencies.